### PR TITLE
Fix spanish_mqd_single import

### DIFF
--- a/plover_spanish_mqd/spanish_mqd_double.py
+++ b/plover_spanish_mqd/spanish_mqd_double.py
@@ -1,4 +1,8 @@
-from . import spanish_mqd_single
+import os
+from plover.oslayer.config import CONFIG_DIR
+
+os.chdir(CONFIG_DIR)
+import spanish_mqd_single 
 
 
 LONGEST_KEY = 2


### PR DESCRIPTION
This should find spanish_mqd_single.py for import correctly within spanish_mqd_double.py.

## Link to issue number: #2 

### Summary of the issue:
Plover reports an error while loading spanish_mqd_double.py dictionary. 

### Description of how this pull request fixes the issue:
Provides the correct path for spanish_mqd_single.py, so it can be imported in spanish_mqd_double.py 

### Testing performed:
Installed locally on my Mac. I was able to activate the system without errors. 

### Known issues with pull request:
Related to #2 

### Change log entry:
Fix import issue so dictionary can be loaded correctly. 
