### PR TITLE
Detect duplicate keys in json files

### DIFF
--- a/plover_spanish_mqd/dictionaries/user_es.json
+++ b/plover_spanish_mqd/dictionaries/user_es.json
@@ -2734,7 +2734,6 @@
 	"TNVEtnia*": "Heredia",
 	"/TNVEtno*": "Hernando",
 	"TNVEtro*": "Heitor",
-	"TNVEtro*": "Héctor",
 	"TNVIAEOsa*": "Huesa",
 	"/TNVIAEOte*": "Huete",
 	"TNVIAEOtra*": "Huerta",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,21 @@
 import os
 import sys
+
 UNIT_DIR = os.path.dirname(os.path.abspath(__file__))
 TOP_DIR = os.path.dirname(os.path.dirname(UNIT_DIR))
 SOURCE_DIR = os.path.join(TOP_DIR, "plover_spanish_mqd")
 DICT_DIR = os.path.join(SOURCE_DIR, "dictionaries")
 sys.path.append(DICT_DIR)
+
+
+def detectDuplicateKeys(orderedPairs):
+	d = {}
+	duplicateKeys = []
+	for k, v in orderedPairs:
+		if k in d:
+			duplicateKeys.append(k)
+		else:
+			d[k] = v
+	if len(duplicateKeys):
+		raise ValueError("\n".join(duplicateKeys))
+	return d

--- a/tests/test_initial.py
+++ b/tests/test_initial.py
@@ -1,7 +1,9 @@
 import unittest
 import os
 import json
+
 from plover_spanish_mqd import system
+from . import detectDuplicateKeys
 
 DICT = os.path.join(os.path.dirname(__file__), "..", "plover_spanish_mqd", "dictionaries", "initial.json")
 
@@ -11,7 +13,7 @@ class TestInitial(unittest.TestCase):
 	def setUp(self):
 		self.keys = "".join(system.KEYS)
 		with open(DICT, encoding='utf-8') as f:
-			self.dict = json.load(f)
+			self.dict = json.load(f, object_pairs_hook=detectDuplicateKeys)
 
 	def tearDown(self):
 		self.keys = None

--- a/tests/test_punctuation.py
+++ b/tests/test_punctuation.py
@@ -1,7 +1,9 @@
 import unittest
 import os
 import json
+
 from plover_spanish_mqd import system
+from . import detectDuplicateKeys
 
 DICT = os.path.join(os.path.dirname(__file__), "..", "plover_spanish_mqd", "dictionaries", "punctuation.json")
 
@@ -11,7 +13,7 @@ class TestPunctuation(unittest.TestCase):
 	def setUp(self):
 		self.keys = "".join(system.KEYS)
 		with open(DICT, encoding='utf-8') as f:
-			self.dict = json.load(f)
+			self.dict = json.load(f, object_pairs_hook=detectDuplicateKeys)
 
 	def tearDown(self):
 		self.keys = None

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,7 +1,9 @@
 import unittest
 import os
 import json
+
 from plover_spanish_mqd import system
+from . import detectDuplicateKeys
 
 DICT = os.path.join(os.path.dirname(__file__), "..", "plover_spanish_mqd", "dictionaries", "user_es.json")
 
@@ -10,8 +12,8 @@ class TestUser(unittest.TestCase):
 
 	def setUp(self):
 		self.keys = "".join(system.KEYS)
-		with open(DICT, encoding='utf-8') as f:
-			self.dict = json.load(f)
+		with open(DICT, encoding="utf-8") as f:
+			self.dict = json.load(f, object_pairs_hook=detectDuplicateKeys)
 
 	def tearDown(self):
 		self.keys = None


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Duplicate keys can be added in json files accidentally, causing that one of them is ignored.
### Description of how this pull request fixes the issue:
A function to detect duplicate keys has been added in tests/__init__.py module, and this is used when json files are loaded to test them.
### Testing performed:
Tested locally: detected a duplicate key in user_es.json, removed in this same PR.
### Known issues with pull request:
None.
### Change log entry:
None: this is not a visible change, it's just used for testing.