### PR TITLE
Cleanup tests

### DIFF
--- a/tests/test_double.py
+++ b/tests/test_double.py
@@ -9,15 +9,10 @@ class TestDouble(unittest.TestCase):
 	def setUp(self):
 		self.keys = "".join(system.KEYS)
 		self.dict = spanish_mqd_double.doubleStrokes
-		self.adjs = spanish_mqd_double.adjs
-		self.irregular = spanish_mqd_double.irregular
 
 	def tearDown(self):
 		self.keys = None
 		self.dict = None
-		self.adjs = None
-		self.irregular = None
-		spanish_mqd_single.lastValue = ""
 
 	def test_keyOrder(self):
 		for k, v in self.dict.items():

--- a/tests/test_double.py
+++ b/tests/test_double.py
@@ -1,5 +1,5 @@
 import unittest
-from plover_spanish_mqd import spanish_mqd_single
+
 from plover_spanish_mqd import spanish_mqd_double
 from plover_spanish_mqd import system
 

--- a/tests/test_initial.py
+++ b/tests/test_initial.py
@@ -19,10 +19,6 @@ class TestInitial(unittest.TestCase):
 		self.keys = None
 		self.dict = None
 
-	def test_keyType(self):
-		for k, v in self.dict.items():
-			self.assertTrue(isinstance(k, str), k)
-
 	def test_keyOrder(self):
 		for k, v in self.dict.items():
 			prevIndex = -1

--- a/tests/test_punctuation.py
+++ b/tests/test_punctuation.py
@@ -19,10 +19,6 @@ class TestPunctuation(unittest.TestCase):
 		self.keys = None
 		self.dict = None
 
-	def test_keyType(self):
-		for k, v in self.dict.items():
-			self.assertTrue(isinstance(k, str), k)
-
 	def test_keyOrder(self):
 		for k, v in self.dict.items():
 			prevIndex = -1

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -19,10 +19,6 @@ class TestUser(unittest.TestCase):
 		self.keys = None
 		self.dict = None
 
-	def test_keyType(self):
-		for k, v in self.dict.items():
-			self.assertTrue(isinstance(k, str), k)
-
 	def test_keyOrder(self):
 		for k, v in self.dict.items():
 			prevIndex = -1


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Some tests aren't needed.
### Description of how this pull request fixes the issue:
- Remove tests to check if names (keys) in JSON files are strings, since this is enforzed in JSON syntax.
- Remove variables not used in test_double.py module (mypy is used to check Python dictionaries).
### Testing performed:
Various tests have been performed locally.
### Known issues with pull request:
None
### Change log entry:
None (this is not a visible change).