### PR TITLE
Compatible with Plover 5.4 versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/nvdaes/plover_spanish_mqd)
 - Minor improvements in dictionary contents
 
+## [3.1.0](https://github.com/nvdaes/plover_spanish_mqd/releases/tag/v3.1.0) - 2026-07-12
+
+### Changed
+
+- Added compatibility with Plover 5.4.
+
 ## [3.0.0](https://github.com/nvdaes/plover_spanish_mqd/releases/tag/v3.0.0) - 2026-05-18
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "plover~=5.3.0",
+    "plover>=5.3.0,<5.5.0",
     "plover_python_dictionary>=1,<2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "plover-spanish-mqd"
-version = "2.2.0"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "plover" },
@@ -503,7 +503,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "plover", specifier = "~=5.3.0" },
+    { name = "plover", specifier = ">=5.3.0,<5.5.0" },
     { name = "plover-python-dictionary", specifier = ">=1,<2" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pyright", marker = "extra == 'dev'" },


### PR DESCRIPTION
- **Add compatibility with Plover 5.4**
- **Update changelog**

<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
Fixes #13
### Summary of the issue:
Plover 5.4.0 is released, but in pyproject.toml, constraints are too restrictive.
### Description of how this pull request fixes the issue:
Added compatibility with 5.4 versions in pyproject.toml.
### Testing performed:
- pytest
- Tested locally with Plover 5.4.0.

### Known issues with pull request:
None

### Change log entry:
* Compatible with Plover 5.4.
